### PR TITLE
Improve integration of acceptance tests

### DIFF
--- a/codeception.dist.yml
+++ b/codeception.dist.yml
@@ -1,21 +1,20 @@
-namespace: WerkraumMedia\Watchlist\Tests\Acceptance\Support
+namespace: 'WerkraumMedia\Watchlist\Tests\Acceptance\Support'
 
 paths:
-  tests: Tests/Acceptance
-  data: Tests/Acceptance/Data
-  output: .Build/web/typo3temp/var/tests/AcceptanceReports
-  support: Tests/Acceptance/Support
-
-extensions:
-  enabled:
-    - Codeception\Extension\RunFailed
+  tests: 'Tests/Acceptance'
+  data: 'Tests/Acceptance/Data'
+  output: '.Build/web/typo3temp/var/tests/AcceptanceReports'
+  support: 'Tests/Acceptance/Support'
 
 suites:
   acceptance:
-    actor: AcceptanceTester
-    path: .
+    actor: 'AcceptanceTester'
+    path: '.'
     extensions:
       enabled:
+        - 'Codeception\Extension\RunProcess':
+            - 'geckodriver > Tests/Acceptance/_output/geckodriver.log 2>&1'
+            - 'TYPO3_PATH_APP="$INSTANCE_PATH" TYPO3_PATH_ROOT="$INSTANCE_PATH" php -S 127.0.0.1:8080 -t "$INSTANCE_PATH" > Tests/Acceptance/_output/php.log 2>&1'
         - WerkraumMedia\Watchlist\Tests\Acceptance\Support\Environment:
             typo3DatabaseUsername: 'testing'
             typo3DatabasePassword: 'testing'

--- a/shell.nix
+++ b/shell.nix
@@ -59,22 +59,10 @@ let
     text = ''
       project-install
 
-      _instance_path="$PROJECT_ROOT/.Build/web/typo3temp/var/tests/acceptance/"
+      export INSTANCE_PATH="$PROJECT_ROOT/.Build/web/typo3temp/var/tests/acceptance/"
 
-      mkdir -p "$_instance_path"
-
-      geckodriver > /dev/null 2>&1 &
-      _pid_geckodriver=$!
-
-      TYPO3_PATH_APP="$_instance_path" \
-        TYPO3_PATH_ROOT="$_instance_path" \
-        php -S 127.0.0.1:8080 -t "$_instance_path" > /dev/null 2>&1 &
-      _pid_php=$!
-
-      ./vendor/bin/codecept build
+      mkdir -p "$INSTANCE_PATH"
       ./vendor/bin/codecept run
-
-      kill "$_pid_geckodriver" "$_pid_php"
     '';
   };
 


### PR DESCRIPTION
Do not handle necessary processes ourself.
Instead use codeception extension.

Wrap strings in yaml to ensure they are not interpreted as something else.