### PR TITLE
Update GitHub checkout action

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -7,7 +7,7 @@ jobs:
   check-composer:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v3
 
       - uses: cachix/install-nix-action@v17
         with:
@@ -26,7 +26,7 @@ jobs:
           - 8.1
     steps:
       - name: Checkout
-        uses: actions/checkout@v2
+        uses: actions/checkout@v3
 
       - name: Install PHP
         uses: shivammathur/setup-php@v2
@@ -41,7 +41,7 @@ jobs:
   xml-linting:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v3
 
       - uses: cachix/install-nix-action@v17
         with:
@@ -53,7 +53,7 @@ jobs:
   coding-guideline:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v3
 
       - uses: cachix/install-nix-action@v17
         with:
@@ -71,7 +71,7 @@ jobs:
           - php-version: '8.0'
           - php-version: '8.1'
     steps:
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v3
 
       - name: Install PHP
         uses: shivammathur/setup-php@v2
@@ -97,7 +97,7 @@ jobs:
           - php-version: '8.0'
           - php-version: '8.1'
     steps:
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v3
 
       - name: Install PHP
         uses: shivammathur/setup-php@v2
@@ -134,7 +134,7 @@ jobs:
   tests-acceptance:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v3
 
       - uses: cachix/install-nix-action@v17
         with:


### PR DESCRIPTION
Necessary as v2 uses old NodeJS which is deprecated.