### PR TITLE
Make tests compatible with TYPO3 core changes

### DIFF
--- a/Tests/Functional/BasicsTest.php
+++ b/Tests/Functional/BasicsTest.php
@@ -44,6 +44,16 @@ class BasicsTest extends FunctionalTestCase
         'typo3conf/ext/watchlist/Tests/Fixtures/Fileadmin/Files' => 'fileadmin/Files',
     ];
 
+    protected $configurationToUseInTestInstance = [
+        'FE' => [
+            'cacheHash' => [
+                'excludedParameters' => [
+                    '^tx_watchlist_watchlist[',
+                ],
+            ],
+        ],
+    ];
+
     protected function setUp(): void
     {
         parent::setUp();


### PR DESCRIPTION
The cHash now is enforced, which will break within functional tests. We adapt the configuration to still execute tests.