### PR TITLE
Fix broken TCA registration of plugin

### DIFF
--- a/Configuration/TCA/Overrides/tt_content.php
+++ b/Configuration/TCA/Overrides/tt_content.php
@@ -13,21 +13,10 @@ defined('TYPO3') || die();
     ]);
 
     ExtensionUtility::registerPlugin(
-        $extKey,
-        $extKey,
+        'Watchlist',
+        'Watchlist',
         $languagePath . 'title',
         'EXT:' . $extKey . '/Resources/Public/Icons/Extension.svg'
-    );
-
-    \TYPO3\CMS\Core\Utility\ExtensionManagementUtility::addTcaSelectItem(
-        $table,
-        'CType',
-        [
-            $languagePath . 'title',
-            $contentType,
-            'content-bullets',
-            'special',
-        ]
     );
 
     \TYPO3\CMS\Core\Utility\ArrayUtility::mergeRecursiveWithOverrule($GLOBALS['TCA'][$table], [

--- a/README.rst
+++ b/README.rst
@@ -151,3 +151,17 @@ Example
 A concrete example can be found within ``Tests/Fixtures/FrontendRendering.typoscript``.
 This example includes the provided JavaScript file as well as some custom CSS and Markup.
 The content element is not necessary.
+
+Changelog
+=========
+
+v1.0.1
+------
+
+* Fix broken registration of plugin as content element within TCA.
+  We used different cases for ExtensionName and PluginName while configuring and registering a plugin.
+  That lead to the issue that the plugin was also registered as list_type aka "Insert Plugin".
+  But there was no rendering definition. We manually added the CType registration.
+
+  This is now fixed by properly calling the registerPlugin() method. That way extbase
+  can find the CType definition and will add it as CType instead of list_type.


### PR DESCRIPTION
We broke the registerPlugin() call by using lower cased version (the extension key) instead of an UpperCamelCase version (the ExtensionName), as opposed to the configurePlugin() call.
Both calls have to be in sync.

This is now adjusted and removes the need for a workaround to call addTcaSelectItem().