### PR TITLE
[FEATURE] Allow replacement of cookie implementation

### DIFF
--- a/Classes/Middleware/CookieSessionMiddleware.php
+++ b/Classes/Middleware/CookieSessionMiddleware.php
@@ -29,14 +29,14 @@ use Psr\Http\Server\MiddlewareInterface;
 use Psr\Http\Server\RequestHandlerInterface;
 use Symfony\Component\HttpFoundation\Cookie;
 use TYPO3\CMS\Core\Http\NormalizedParams;
-use WerkraumMedia\Watchlist\Session\CookieSessionService;
+use WerkraumMedia\Watchlist\Session\CookieSessionInterface;
 
 class CookieSessionMiddleware implements MiddlewareInterface
 {
-    private CookieSessionService $cookieSession;
+    private CookieSessionInterface $cookieSession;
 
     public function __construct(
-        CookieSessionService $cookieSession
+        CookieSessionInterface $cookieSession
     ) {
         $this->cookieSession = $cookieSession;
     }

--- a/Classes/Session/CookieSessionInterface.php
+++ b/Classes/Session/CookieSessionInterface.php
@@ -1,0 +1,10 @@
+<?php
+
+namespace WerkraumMedia\Watchlist\Session;
+
+interface CookieSessionInterface
+{
+    public function getCookieName(): string;
+
+    public function getCookieValue(): string;
+}

--- a/Classes/Session/CookieSessionService.php
+++ b/Classes/Session/CookieSessionService.php
@@ -28,7 +28,7 @@ use TYPO3\CMS\Extbase\Property\PropertyMapper;
 use WerkraumMedia\Watchlist\Domain\Model\Item;
 use WerkraumMedia\Watchlist\Domain\Model\Watchlist;
 
-class CookieSessionService implements SessionServiceInterface
+class CookieSessionService implements CookieSessionInterface, SessionServiceInterface
 {
     private PropertyMapper $propertyMapper;
 

--- a/README.rst
+++ b/README.rst
@@ -159,6 +159,14 @@ The content element is not necessary.
 Changelog
 =========
 
+v1.1.0
+------
+
+* Allow replacement of cookie implementation.
+  The implementation is now extracted into an interface.
+  That way it is easier to replace the concrete implementation for cookie handling
+  with a custom one.
+
 v1.0.1
 ------
 


### PR DESCRIPTION
The implementation is now extracted into an interface.
That way it is easier to replace the concrete implementation for cookie
handling
with a custom one.

Relates: #21